### PR TITLE
Switch F4D base image from Fedora to Ubuntu

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,9 +2,9 @@ FROM ubuntu:focal
 
 RUN apt update && \
     DEBIAN_FRONTEND="noninteractive" apt install -y tzdata && \
-    apt install -y make gcc gfortran curl wget less && \
-    apt install -y python tk gnuplot-x11 python-tk python-numpy desktop-file-utils && \
-    apt install -y python-imaging-tk && \
+    DEBIAN_FRONTEND="noninteractive" apt install -y make gcc gfortran curl wget less && \
+    DEBIAN_FRONTEND="noninteractive" apt install -y python tk gnuplot-x11 python-tk python-numpy desktop-file-utils && \
+    DEBIAN_FRONTEND="noninteractive" apt install -y python-imaging-tk && \
     curl https://bootstrap.pypa.io/pip/2.7/get-pip.py --output get-pip.py && \
     python get-pip.py && \
     apt clean && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,10 @@
-FROM fedora:34
+FROM ubuntu:focal
 
-# Using the list of packages from
-# https://fluka-forum.web.cern.ch/t/software-requirements-of-fluka-and-flair/94
-
-RUN dnf update -y && \
-    dnf install -y make gcc-gfortran \ 
-                   python-pillow-tk python-scipy python-numpy python-matplotlib \
-                   python-pydicom gnuplot \
-                   which less emacs desktop-file-utils && \
-    dnf clean all 
+RUN apt update && \
+    apt install -y make gcc gfortran curl wget less && \
+    apt install -y python tk gnuplot-x11 python-tk python-numpy desktop-file-utils && \
+    apt install -y python-imaging-tk && \
+    curl https://bootstrap.pypa.io/pip/2.7/get-pip.py --output get-pip.py && \
+    python get-pip.py && \
+    apt clean && \
+    pip install -U pydicom

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,4 +8,5 @@ RUN apt update && \
     curl https://bootstrap.pypa.io/pip/2.7/get-pip.py --output get-pip.py && \
     python get-pip.py && \
     apt clean && \
-    pip install -U pydicom
+    pip install -U pydicom && \
+    rm get-pip.py

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM ubuntu:focal
 
 RUN apt update && \
+    DEBIAN_FRONTEND="noninteractive" apt install -y tzdata && \
     apt install -y make gcc gfortran curl wget less && \
     apt install -y python tk gnuplot-x11 python-tk python-numpy desktop-file-utils && \
     apt install -y python-imaging-tk && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,11 @@
-FROM fedora:30
+FROM fedora:34
+
+# Using the list of packages from
+# https://fluka-forum.web.cern.ch/t/software-requirements-of-fluka-and-flair/94
 
 RUN dnf update -y && \
-    dnf install -y make gcc-gfortran findutils wget htop yum-plugin-ovl \
-                   gnuplot python tk tkinter python-imaging-tk \
-		   which less emacs \
-                   python2-pip python2-scipy python2-numpy desktop-file-utils && \
-    dnf clean all && \
-    pip install -U pydicom
-    
+    dnf install -y make gcc-gfortran \ 
+                   python-pillow-tk python-scipy python-numpy python-matplotlib \
+                   python-pydicom gnuplot \
+                   which less emacs desktop-file-utils && \
+    dnf clean all 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
 # F4D_baseimage
 Fluka for Docker base image
 
+**This repo is no longer active. Fluka is now updated with Python 3, so distros with Python 2 is no longer needed for Fluka to work. See https://github.com/flukadocker/F4D/pull/4#issuecomment-1475968541 for more info.**
+
+**If you would like to install Fluka via F4D, please refer to installation instructions at https://github.com/flukadocker/F4D/.**
+
 Original script by D. Horváth
  
 This script generates the ~~Fedora~~ Ubuntu base image used to run Fluka and Flair inside Docker, based on Ubuntu 20.04 LTS. This version of Ubuntu has a very long support cycle, with its maintenance support ending in 2025.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,18 @@
 # F4D_baseimage
 Fluka for Docker base image
 
-D. Horváth
+Original script by D. Horváth
  
-This script generates the Fedora base image used to run Fluka and Flair inside Docker.  
+This script generates the ~~Fedora~~ Ubuntu base image used to run Fluka and Flair inside Docker, based on Ubuntu 20.04 LTS. This version of Ubuntu has a very long support cycle, with its maintenance support ending in 2025.
+
+## Installation
+This Docker base image is designed to work with my forked version of Fluka for Docker project by @flukadocker here: github.com/vicha-w/F4D.
+
+1. Clone this repository
+
+    ``` git clone https://github.com/vicha-w/F4D_baseimage.git```
+2. `cd F4D_baseimage`
+3. Build Docker base image. **Tag name `f4d_base_ubuntu_focal` is mandatory in order to work with F4D fork.**
+
+    ``` docker build -t f4d_base_ubuntu_focal .```
+4. You now have F4D base image on Docker to work with. To confirm this, type `docker images` and look for `f4d_base_ubuntu_focal`.


### PR DESCRIPTION
Dear F4D developers,

One of my colleagues has started working on Fluka, and she was interested in installing Fluka via your F4D solution. Unfortunately she couldn't install it on her Windows machine, so she asked me for help.

Upon inspection, I have pinpointed that the current F4D image in Docker Hub is based on Fedora 30, which as far as I remember has Python 2 but not the latest C libraries. I tried switching to Fedora 34, but it doesn't have Python 2. I then decided to switch to Ubuntu 20.04 LTS, which is supposed to have its end of life on April, 2025. It also has _both_ Python 2 and the latest C libraries, allowing us to compile Fluka without errors.

This pull request should be reviewed alongside my other pull request for flukadocker/F4D, https://github.com/flukadocker/F4D/pull/4, since I forked F4D_baseimage, switched to Ubuntu, and forked F4D repo based on my Ubuntu base image. Please also note that there is another fork of this repo which switched from Ubuntu to Debian.

Please let me know if you need any further information.

Yours faithfully,
Vichayanun